### PR TITLE
fix: make StreamEmitter.close idempotent to prevent double-close race

### DIFF
--- a/src/codex-app-server-language-model.ts
+++ b/src/codex-app-server-language-model.ts
@@ -311,10 +311,16 @@ export class CodexAppServerLanguageModel implements LanguageModelV3 {
           }
         };
 
+        // Detach the caller's abort listener once the turn ends naturally,
+        // so a later AbortSignal.timeout() firing cannot reach into already-
+        // closed state and crash with ERR_INVALID_STATE.
+        const abortListenerController = new AbortController();
+
         const router = new NotificationRouter(client, emitter, {
           threadId,
           turnId,
           onTurnCompleted: (status, error) => {
+            abortListenerController.abort();
             session._setInactive();
             emitter.emitFinish(status, error);
             emitter.close();
@@ -325,16 +331,20 @@ export class CodexAppServerLanguageModel implements LanguageModelV3 {
 
         router.subscribe();
 
-        options.abortSignal?.addEventListener('abort', async () => {
-          try {
-            await session.interrupt();
-          } catch {
-            // Ignore interrupt errors
-          }
-          router.unsubscribe();
-          emitter.close();
-          cleanup();
-        });
+        options.abortSignal?.addEventListener(
+          'abort',
+          async () => {
+            try {
+              await session.interrupt();
+            } catch {
+              // Ignore interrupt errors
+            }
+            router.unsubscribe();
+            emitter.close();
+            cleanup();
+          },
+          { signal: abortListenerController.signal }
+        );
       },
       cancel: () => {},
     });

--- a/src/stream/stream-emitter.test.ts
+++ b/src/stream/stream-emitter.test.ts
@@ -108,6 +108,42 @@ describe('StreamEmitter', () => {
     });
   });
 
+  describe('close', () => {
+    test('close() is idempotent — second call is a no-op', () => {
+      const { controller } = createMockController();
+      const emitter = new StreamEmitter(controller, {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        modelId: 'codex',
+      });
+
+      emitter.close();
+      emitter.close();
+
+      expect(controller.close).toHaveBeenCalledTimes(1);
+    });
+
+    test('close() after close() does not throw on a real ReadableStreamDefaultController', () => {
+      // The real ReadableStreamDefaultController.close() throws
+      // ERR_INVALID_STATE when called on an already-closed controller.
+      // This regression-tests the actual production failure mode.
+      let realController!: ReadableStreamDefaultController<LanguageModelV3StreamPart>;
+      new ReadableStream<LanguageModelV3StreamPart>({
+        start(controller) {
+          realController = controller;
+        },
+      });
+      const emitter = new StreamEmitter(realController, {
+        threadId: 'thread-1',
+        turnId: 'turn-1',
+        modelId: 'codex',
+      });
+
+      expect(() => emitter.close()).not.toThrow();
+      expect(() => emitter.close()).not.toThrow();
+    });
+  });
+
   describe('emitFinish', () => {
     test('includes sessionId in finish providerMetadata for session resumption', () => {
       const { controller, enqueued } = createMockController();

--- a/src/stream/stream-emitter.ts
+++ b/src/stream/stream-emitter.ts
@@ -98,6 +98,7 @@ export class StreamEmitter {
   private reasoningId = randomUUID();
   private textStarted = false;
   private reasoningStarted = false;
+  private closed = false;
 
   // Tool execution tracking
   private toolStats: ToolExecutionStats = {
@@ -260,6 +261,8 @@ export class StreamEmitter {
   }
 
   close(): void {
+    if (this.closed) return;
+    this.closed = true;
     this.controller.close();
   }
 }


### PR DESCRIPTION
## Summary

A reproducible `TypeError [ERR_INVALID_STATE]: Controller is already closed` is thrown into the event loop whenever a Codex stream completes naturally via `turn.completed` AND the caller's `AbortSignal` fires later — a common pattern when callers pass an `AbortSignal.timeout()` whose duration outlives the turn (safety timeout). The crash is deterministic, not flaky.

**Stack trace (from the downstream report):**

```
TypeError: Invalid state: Controller is already closed
 code: "ERR_INVALID_STATE"
      at StreamEmitter.close (dist/index.js:1381:21)
      at <anonymous>        (dist/index.js:1768:19)
```

## Root cause

Two issues conspired:

1. [`StreamEmitter.close()`](https://github.com/pablof7z/ai-sdk-provider-codex-app-server/blob/d655ec0/src/stream/stream-emitter.ts#L262-L264) wrapped `ReadableStreamDefaultController.close()` with no guard. The native primitive throws `ERR_INVALID_STATE` on a second invocation.
2. The [abort-signal listener registered in `doStream`](https://github.com/pablof7z/ai-sdk-provider-codex-app-server/blob/d655ec0/src/codex-app-server-language-model.ts#L328-L337) was never removed when the turn completed naturally, so a later abort would re-enter `emitter.close()` (and `router.unsubscribe()` / `cleanup()`) against already-closed state.

Timeline of the crash:

1. `t=0` — caller starts request with `AbortSignal.timeout(5min)` as a safety timeout.
2. `t=10s` — Codex finishes, `turn/completed` fires → first `emitter.close()` runs cleanly, controller is now closed.
3. `t=5min` — the timeout signal fires → still-attached `'abort'` listener runs → second `emitter.close()` → `controller.close()` throws `ERR_INVALID_STATE` into the event loop, minutes after the user got a successful response.

## Changes

1. `StreamEmitter.close()` now checks a private `closed` boolean and returns early on subsequent calls. **This alone prevents the crash.**
2. The abort listener is registered with `{ signal: ... }` against an internal `AbortController` (`abortListenerController`). `onTurnCompleted` calls `abortListenerController.abort()` synchronously *first*, before any other cleanup, which detaches the listener via the `EventTarget` `signal` option. This closes the race window entirely and lets the closure be GC'd.

## Tests

Added two tests in `src/stream/stream-emitter.test.ts`:

- `close() is idempotent — second call is a no-op` — uses the existing mock controller; asserts `controller.close` was called exactly once.
- `close() after close() does not throw on a real ReadableStreamDefaultController` — regression test against the actual production failure mode (`ERR_INVALID_STATE`).

Both new tests **fail against the unfixed source with the verbatim production error**, and pass with the fix applied. Existing 6 tests remain green (8/8 total).

## Notes

- **No API surface change. Minimal diff** (+59/-10 across 3 source files; no `dist/` changes).
- No new dependencies.
- No version bump in this PR — leaving that to maintainer discretion.